### PR TITLE
fixed bug Sqlsrv

### DIFF
--- a/src/apps/lib/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
+++ b/src/apps/lib/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
@@ -336,7 +336,7 @@ class Sqlsrv extends \Phalcon\Db\Adapter\Pdo\AbstractPdo
             $cursor = \PDO::CURSOR_FWDONLY;
         }
 
-        $sqlStatement = str_replace('rowcount', '[rowcount]', $sqlStatement);
+        $sqlStatement = str_replace('AS rowcount ', 'AS [rowcount] ', $sqlStatement);
         
         $statement = null;
         if (is_array($bindParams)) {

--- a/src/apps/lib/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
+++ b/src/apps/lib/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
@@ -336,6 +336,8 @@ class Sqlsrv extends \Phalcon\Db\Adapter\Pdo\AbstractPdo
             $cursor = \PDO::CURSOR_FWDONLY;
         }
 
+        $sqlStatement = str_replace('rowcount', '[rowcount]', $sqlStatement);
+        
         $statement = null;
         if (is_array($bindParams)) {
             

--- a/src/apps/lib/Phalcon/Db/Result/PdoSqlsrv.php
+++ b/src/apps/lib/Phalcon/Db/Result/PdoSqlsrv.php
@@ -34,7 +34,7 @@ class PdoSqlsrv extends Pdo
                 parent::numRows();
             }
 
-            $this->_rowCount = $rowCount;
+            $this->rowCount = $rowCount;
         }
 
         return $rowCount;


### PR DESCRIPTION
### Problem
Incorrect syntax near the keyword 'rowcount'.

### How to produce bug
`Model::count()`
or 
`Model::countData()` where count*() is a method from relationship model

[Model.zep](https://github.com/phalcon/cphalcon/blob/d3e94630156a0c4441bf5f72e6ed071941c5908b/phalcon/Mvc/Model.zep#L975)
[Model\Manager.zep](https://github.com/phalcon/cphalcon/blob/d3e94630156a0c4441bf5f72e6ed071941c5908b/phalcon/Mvc/Model/Manager.zep#L1477-L1485)